### PR TITLE
use add repository and rebase to resolute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
+FROM ghcr.io/linuxserver/baseimage-selkies:ubunturesolute
 
 # set version label
 ARG BUILD_DATE
@@ -18,12 +18,7 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/retroarch-logo.png && \
   echo "**** install packages ****" && \
-  apt-key adv \
-    --keyserver hkp://keyserver.ubuntu.com:80 \
-    --recv-keys 3B2BA0B6750986899B189AFF18DAAE7FECA3745F && \
-  echo \
-    "deb https://ppa.launchpadcontent.net/libretro/stable/ubuntu noble main" > \
-    /etc/apt/sources.list.d/retroarch.list && \
+  add-apt-repository ppa:libretro/stable && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libretro-core-info \
@@ -44,6 +39,8 @@ RUN \
     > /build_version && \
   apt-get clean && \
   rm -rf \
+    /config/.cache \
+    /config/.launchpadlib \
     /tmp/* \
     /var/lib/apt/lists/* \
     /var/tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-ubuntunoble
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-ubunturesolute
 
 # set version label
 ARG BUILD_DATE
@@ -18,12 +18,7 @@ RUN \
     /usr/share/selkies/www/icon.png \
     https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/retroarch-logo.png && \
   echo "**** install packages ****" && \
-  apt-key adv \
-    --keyserver hkp://keyserver.ubuntu.com:80 \
-    --recv-keys 3B2BA0B6750986899B189AFF18DAAE7FECA3745F && \
-  echo \
-    "deb https://ppa.launchpadcontent.net/libretro/stable/ubuntu noble main" > \
-    /etc/apt/sources.list.d/retroarch.list && \
+  add-apt-repository ppa:libretro/stable && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libretro-core-info \
@@ -43,7 +38,10 @@ RUN \
     "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" \
     > /build_version && \
   apt-get clean && \
+  apt-get clean && \
   rm -rf \
+    /config/.cache \
+    /config/.launchpadlib \
     /tmp/* \
     /var/lib/apt/lists/* \
     /var/tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -38,7 +38,6 @@ RUN \
     "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" \
     > /build_version && \
   apt-get clean && \
-  apt-get clean && \
   rm -rf \
     /config/.cache \
     /config/.launchpadlib \

--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **19.04.26:** - Rebase to Resolute.
 * **05.03.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **20.12.25:** - Add Wayland init logic.
 * **25.05.25:** - Initial Version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -109,6 +109,7 @@ init_diagram: |
   "retroarch:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "19.04.26:", desc: "Rebase to Resolute."}
   - {date: "05.03.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "20.12.25:", desc: "Add Wayland init logic."}
   - {date: "25.05.25:", desc: "Initial Version."}


### PR DESCRIPTION
Noble is busted at head it just segfaults when using the interposer. 

This uses apt add and rebases to resolute to get head running on CPU only systems again. 